### PR TITLE
fix: add license identifier to CMake file

### DIFF
--- a/src/f2py_cmake/cmake/UseF2Py.cmake
+++ b/src/f2py_cmake/cmake/UseF2Py.cmake
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 if(CMAKE_VERSION VERSION_LESS 3.17)
   message(FATAL_ERROR "CMake 3.17+ required")
 endif()


### PR DESCRIPTION
Make sure the file has a identifier if it gets vendored.
