### PR TITLE
Expand semicolon list of files for multiple file targets.

### DIFF
--- a/src/f2py_cmake/cmake/UseF2Py.cmake
+++ b/src/f2py_cmake/cmake/UseF2Py.cmake
@@ -117,7 +117,7 @@ function(f2py_generate_module NAME)
     VERBATIM
     COMMAND
       "${${_Python}_EXECUTABLE}" -m numpy.f2py
-      "${abs_all_files}" ${_file_arg} ${lower} "${F2PY_F2PY_ARGS}"
+      "${abs_all_files}" "${_file_arg}" ${lower} "${F2PY_F2PY_ARGS}"
     COMMAND_EXPAND_LISTS
     COMMAND
       "${CMAKE_COMMAND}" -E touch ${wrapper_files}

--- a/src/f2py_cmake/cmake/UseF2Py.cmake
+++ b/src/f2py_cmake/cmake/UseF2Py.cmake
@@ -117,7 +117,7 @@ function(f2py_generate_module NAME)
     VERBATIM
     COMMAND
       "${${_Python}_EXECUTABLE}" -m numpy.f2py
-      "${abs_all_files}" ${_file_arg} ${lower} ${F2PY_F2PY_ARGS}
+      "${abs_all_files}" ${_file_arg} ${lower} "${F2PY_F2PY_ARGS}"
     COMMAND_EXPAND_LISTS
     COMMAND
       "${CMAKE_COMMAND}" -E touch ${wrapper_files}

--- a/src/f2py_cmake/cmake/UseF2Py.cmake
+++ b/src/f2py_cmake/cmake/UseF2Py.cmake
@@ -118,6 +118,7 @@ function(f2py_generate_module NAME)
     COMMAND
       "${${_Python}_EXECUTABLE}" -m numpy.f2py
       "${abs_all_files}" ${_file_arg} ${lower} ${F2PY_F2PY_ARGS}
+    COMMAND_EXPAND_LISTS
     COMMAND
       "${CMAKE_COMMAND}" -E touch ${wrapper_files}
     WORKING_DIRECTORY "${F2PY_OUTPUT_DIR}"


### PR DESCRIPTION
Found on multiple Fortran file modules, the file list was being passed as a double-quoted, semicolon delimited list. 

Adding the `COMMAND_EXPAND_LISTS` to `add_custom_command` in the function f2py_generate_module fixed this. 