### PR TITLE
fix: make f2py_generate_module output and input paths absolute

### DIFF
--- a/src/f2py_cmake/cmake/UseF2Py.cmake
+++ b/src/f2py_cmake/cmake/UseF2Py.cmake
@@ -64,8 +64,14 @@ function(f2py_generate_module NAME)
     set(F2PY_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
   endif()
 
+  set(abs_pyf_file)
   if(NAME MATCHES "\\.pyf$")
-    set(_file_arg "${NAME}")
+    if(IS_ABSOLUTE "${NAME}")
+      set(abs_pyf_file "${NAME}")
+    else()
+      set(abs_pyf_file "${CMAKE_CURRENT_SOURCE_DIR}/${NAME}")
+    endif()
+    set(_file_arg "${abs_pyf_file}")
     get_filename_component(NAME "${NAME}" NAME_WE)
   else()
     set(_file_arg -m ${NAME})
@@ -96,6 +102,12 @@ function(f2py_generate_module NAME)
     set(wrapper_files ${NAME}-f2pywrappers.f ${NAME}-f2pywrappers2.f90)
   endif()
 
+  set(module_output "${F2PY_OUTPUT_DIR}/${NAME}module.c")
+  set(abs_wrapper_files)
+  foreach(wrapper IN LISTS wrapper_files)
+    list(APPEND abs_wrapper_files "${F2PY_OUTPUT_DIR}/${wrapper}")
+  endforeach()
+
   if(F2PY_NOLOWER)
     set(lower "--no-lower")
   else()
@@ -112,15 +124,15 @@ function(f2py_generate_module NAME)
   endforeach()
 
   add_custom_command(
-    OUTPUT ${NAME}module.c ${wrapper_files}
-    DEPENDS ${ALL_FILES}
+    OUTPUT ${module_output} ${abs_wrapper_files}
+    DEPENDS ${abs_all_files} ${abs_pyf_file}
     VERBATIM
     COMMAND
       "${${_Python}_EXECUTABLE}" -m numpy.f2py
       "${abs_all_files}" "${_file_arg}" ${lower} "${F2PY_F2PY_ARGS}"
     COMMAND_EXPAND_LISTS
     COMMAND
-      "${CMAKE_COMMAND}" -E touch ${wrapper_files}
+      "${CMAKE_COMMAND}" -E touch ${abs_wrapper_files}
     WORKING_DIRECTORY "${F2PY_OUTPUT_DIR}"
     COMMENT
       "F2PY making ${NAME} wrappers"
@@ -130,7 +142,7 @@ function(f2py_generate_module NAME)
   # wrappers call. Omitting them only links on platforms that allow undefined
   # symbols in shared libraries (i.e. not Windows).
   if(F2PY_OUTPUT_VARIABLE)
-    set(${F2PY_OUTPUT_VARIABLE} ${NAME}module.c ${wrapper_files} ${abs_all_files}
+    set(${F2PY_OUTPUT_VARIABLE} ${module_output} ${abs_wrapper_files} ${abs_all_files}
                                 PARENT_SCOPE)
   endif()
 endfunction()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes three related path-handling bugs in `f2py_generate_module` in `src/f2py_cmake/cmake/UseF2Py.cmake`. The `add_custom_command` runs with `WORKING_DIRECTORY "${F2PY_OUTPUT_DIR}"`, but several paths were left relative and resolved against the wrong directory.

## Fixes

1. **`OUTPUT_DIR` was broken for non-default values.** The declared `OUTPUT` and the `OUTPUT_VARIABLE` return values used relative names, which CMake resolves against `CMAKE_CURRENT_BINARY_DIR`, so the declared output location diverged from where f2py actually wrote the files (the `WORKING_DIRECTORY`). The module C file, the wrapper files, and the `cmake -E touch` targets are now absolute, prefixed with `${F2PY_OUTPUT_DIR}/`. Default behavior is unchanged because `F2PY_OUTPUT_DIR` defaults to `${CMAKE_CURRENT_BINARY_DIR}`.

2. **A relative `.pyf` path resolved against the wrong directory.** `_file_arg` kept the raw (possibly relative) path and was passed to f2py running in the binary dir, not the source dir. It is now made absolute (relative to `${CMAKE_CURRENT_SOURCE_DIR}` if not already absolute), the same way `abs_all_files` is built, and is added to `DEPENDS`.

3. **`DEPENDS` used raw, not absolute, paths.** `DEPENDS ${ALL_FILES}` used the possibly-relative inputs while the command used `abs_all_files`; it now uses `${abs_all_files}` plus the absolute pyf file.

## Testing

`uv run pytest` passes all 4 tests, including the cmake-driven `test_f77` and `test_f90` (cmake 4.3.3 on PATH). `test_f90` exercises the `.pyf` path via the `f90dual` fixture.

Refs #48