### PR TITLE
perf: cache f2py include detection and drop unused F2PY_OBJECT_FILES

### DIFF
--- a/src/f2py_cmake/cmake/UseF2Py.cmake
+++ b/src/f2py_cmake/cmake/UseF2Py.cmake
@@ -18,22 +18,23 @@ else()
   message(FATAL_ERROR "You must find Python or Python3 with the NumPy component before including F2PY!")
 endif()
 
-execute_process(
-  COMMAND "${${_Python}_EXECUTABLE}" -c
-          "import numpy.f2py; print(numpy.f2py.get_include())"
-                  OUTPUT_VARIABLE F2PY_inc_output
-                  ERROR_VARIABLE F2PY_inc_error
-                  RESULT_VARIABLE F2PY_inc_result
-                  OUTPUT_STRIP_TRAILING_WHITESPACE
-                  ERROR_STRIP_TRAILING_WHITESPACE)
+if(NOT DEFINED F2PY_INCLUDE_DIR)
+  execute_process(
+    COMMAND "${${_Python}_EXECUTABLE}" -c
+            "import numpy.f2py; print(numpy.f2py.get_include())"
+    OUTPUT_VARIABLE F2PY_inc_output
+    ERROR_VARIABLE F2PY_inc_error
+    RESULT_VARIABLE F2PY_inc_result
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_STRIP_TRAILING_WHITESPACE)
 
-if(NOT F2PY_inc_result EQUAL 0)
-  message(FATAL_ERROR "Can't find f2py, got ${F2PY_inc_output} ${F2PY_inc_error}")
+  if(NOT F2PY_inc_result EQUAL 0)
+    message(FATAL_ERROR "Can't find f2py, got ${F2PY_inc_output} ${F2PY_inc_error}")
+  endif()
+
+  set(F2PY_INCLUDE_DIR "${F2PY_inc_output}" CACHE STRING "")
+  mark_as_advanced(F2PY_INCLUDE_DIR)
 endif()
-
-set(F2PY_INCLUDE_DIR "${F2PY_inc_output}" CACHE STRING "" FORCE)
-set(F2PY_OBJECT_FILES "${F2PY_inc_output}/fortranobject.c;${F2PY_inc_output}/fortranobject.h" CACHE STRING "" FORCE)
-mark_as_advanced(F2PY_INCLUDE_DIR F2PY_OBJECT_FILES)
 
 add_library(F2Py::Headers IMPORTED INTERFACE)
 target_include_directories(F2Py::Headers INTERFACE "${F2PY_INCLUDE_DIR}")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

- **Item 5**: Guard the `execute_process` block that shells out to Python with `if(NOT DEFINED F2PY_INCLUDE_DIR)`, so the detection only runs on the first configure. Drop the `FORCE` keyword so the cached value is respected on subsequent configures. The `add_library`/`target_include_directories` calls remain outside the guard so targets are always registered.
- **Item 6**: Remove the `F2PY_OBJECT_FILES` cache variable — it was set and marked advanced but never read anywhere in the repo (`f2py_object_library` uses `${F2PY_INCLUDE_DIR}/fortranobject.c` directly). Also remove it from the `mark_as_advanced()` call.

Refs #48

## Test plan

- [x] `prek -a --quiet` passes (prettier reformatted AGENTS.md line wrapping; cmake hook passes)
- [x] `uv run pytest` — all 4 tests pass including `test_f77` and `test_f90` (cmake 4.3.3 found on PATH)