### PR TITLE
feat: add f2py_generate_signature for .pyf generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ also provide the following helper functions:
 ```cmake
 f2py_object_library(<name> <type>)
 
+f2py_generate_signature(<module> <files>...
+                  OUTPUT <Signature>
+                  [OUTPUT_VARIABLE <OutputVariable>]
+                  [NOLOWER]
+                  [F2PY_ARGS <args> ...]
+                  )
+
 f2py_generate_module(<module> <files>...
                   [F2PY_ARGS <args> ...]
                   [F77 | F90]
@@ -54,6 +61,25 @@ f2py_generate_module(fibby fib1.f OUTPUT_VARIABLE fibby_files)
 
 python_add_library(fibby MODULE "${fibby_files}" WITH_SOABI)
 target_link_libraries(fibby PRIVATE f2py_object)
+```
+
+## Signatures
+
+`f2py_generate_signature` generates a `.pyf` signature file from Fortran
+sources, which `f2py_generate_module` can then consume as its `<module>`
+argument. f2py's `skip:`/`only:` selectors restrict which routines are wrapped;
+write them inline among the source files (a `skip:`/`only:` block runs until a
+bare `:`):
+
+```cmake
+f2py_generate_signature(mymod a.f90 b.f90 "only:" public_api ":"
+                        OUTPUT mymod.pyf OUTPUT_VARIABLE mymod_sig)
+
+# The signature defines the interface; a.f90/b.f90 are compiled and linked.
+f2py_generate_module(${mymod_sig} a.f90 b.f90 OUTPUT_VARIABLE mymod_files)
+
+python_add_library(mymod MODULE "${mymod_files}" WITH_SOABI)
+target_link_libraries(mymod PRIVATE f2py_object)
 ```
 
 ## scikit-build-core

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ f2py_object_library(<name> <type>)
 
 f2py_generate_signature(<module> <files>...
                   OUTPUT <Signature>
+                  [ONLY <functions> ...]
+                  [SKIP <functions> ...]
                   [OUTPUT_VARIABLE <OutputVariable>]
                   [NOLOWER]
                   [F2PY_ARGS <args> ...]
@@ -67,12 +69,12 @@ target_link_libraries(fibby PRIVATE f2py_object)
 
 `f2py_generate_signature` generates a `.pyf` signature file from Fortran
 sources, which `f2py_generate_module` can then consume as its `<module>`
-argument. f2py's `skip:`/`only:` selectors restrict which routines are wrapped;
-write them inline among the source files (a `skip:`/`only:` block runs until a
-bare `:`):
+argument. `ONLY` and `SKIP` restrict which routines are wrapped (a thin wrapper
+over f2py's `only:`/`skip:` selectors):
 
 ```cmake
-f2py_generate_signature(mymod a.f90 b.f90 "only:" public_api ":"
+f2py_generate_signature(mymod a.f90 b.f90
+                        ONLY public_api
                         OUTPUT mymod.pyf OUTPUT_VARIABLE mymod_sig)
 
 # The signature defines the interface; a.f90/b.f90 are compiled and linked.

--- a/src/f2py_cmake/cmake/UseF2Py.cmake
+++ b/src/f2py_cmake/cmake/UseF2Py.cmake
@@ -53,12 +53,16 @@ function(f2py_generate_signature MODULE)
     F2PY
     "NOLOWER"
     "OUTPUT;OUTPUT_VARIABLE"
-    "F2PY_ARGS"
+    "F2PY_ARGS;SKIP;ONLY"
   )
-  set(ALL_ARGS ${F2PY_UNPARSED_ARGUMENTS})
+  set(ALL_FILES ${F2PY_UNPARSED_ARGUMENTS})
 
   if(NOT F2PY_OUTPUT)
     message(FATAL_ERROR "OUTPUT <signature.pyf> is required")
+  endif()
+
+  if(NOT ALL_FILES)
+    message(FATAL_ERROR "One or more input files must be specified")
   endif()
 
   if(IS_ABSOLUTE "${F2PY_OUTPUT}")
@@ -67,32 +71,23 @@ function(f2py_generate_signature MODULE)
     set(abs_pyf_file "${CMAKE_CURRENT_BINARY_DIR}/${F2PY_OUTPUT}")
   endif()
 
-  # Walk the arguments, absolutizing source files but passing f2py's skip:/only:
-  # routine selectors through untouched. A skip:/only: token opens a block of
-  # routine names that runs until a bare ":"; those names are not paths.
-  set(passthrough_args)
   set(abs_source_files)
-  set(in_selector_block FALSE)
-  foreach(arg IN LISTS ALL_ARGS)
-    if(arg STREQUAL "skip:" OR arg STREQUAL "only:")
-      set(in_selector_block TRUE)
-      list(APPEND passthrough_args "${arg}")
-    elseif(arg STREQUAL ":")
-      set(in_selector_block FALSE)
-      list(APPEND passthrough_args "${arg}")
-    elseif(in_selector_block)
-      list(APPEND passthrough_args "${arg}")
-    elseif(IS_ABSOLUTE "${arg}")
-      list(APPEND passthrough_args "${arg}")
-      list(APPEND abs_source_files "${arg}")
+  foreach(file IN LISTS ALL_FILES)
+    if(IS_ABSOLUTE "${file}")
+      list(APPEND abs_source_files "${file}")
     else()
-      list(APPEND passthrough_args "${CMAKE_CURRENT_SOURCE_DIR}/${arg}")
-      list(APPEND abs_source_files "${CMAKE_CURRENT_SOURCE_DIR}/${arg}")
+      list(APPEND abs_source_files "${CMAKE_CURRENT_SOURCE_DIR}/${file}")
     endif()
   endforeach()
 
-  if(NOT abs_source_files)
-    message(FATAL_ERROR "One or more input files must be specified")
+  # Translate the ONLY/SKIP routine filters into f2py's "only: <names> :" /
+  # "skip: <names> :" selector blocks (each runs until a bare ":").
+  set(selectors)
+  if(F2PY_ONLY)
+    list(APPEND selectors "only:" ${F2PY_ONLY} ":")
+  endif()
+  if(F2PY_SKIP)
+    list(APPEND selectors "skip:" ${F2PY_SKIP} ":")
   endif()
 
   if(F2PY_NOLOWER)
@@ -110,7 +105,7 @@ function(f2py_generate_signature MODULE)
     COMMAND
       "${${_Python}_EXECUTABLE}" -m numpy.f2py
       -h "${abs_pyf_file}" --overwrite-signature -m "${MODULE}"
-      ${passthrough_args} ${lower} "${F2PY_F2PY_ARGS}"
+      ${abs_source_files} ${selectors} ${lower} "${F2PY_F2PY_ARGS}"
     COMMAND_EXPAND_LISTS
     COMMENT
       "F2PY generating ${MODULE} signature"

--- a/src/f2py_cmake/cmake/UseF2Py.cmake
+++ b/src/f2py_cmake/cmake/UseF2Py.cmake
@@ -47,6 +47,82 @@ function(f2py_object_library NAME TYPE)
   endif()
 endfunction()
 
+function(f2py_generate_signature MODULE)
+  cmake_parse_arguments(
+    PARSE_ARGV 1
+    F2PY
+    "NOLOWER"
+    "OUTPUT;OUTPUT_VARIABLE"
+    "F2PY_ARGS"
+  )
+  set(ALL_ARGS ${F2PY_UNPARSED_ARGUMENTS})
+
+  if(NOT F2PY_OUTPUT)
+    message(FATAL_ERROR "OUTPUT <signature.pyf> is required")
+  endif()
+
+  if(IS_ABSOLUTE "${F2PY_OUTPUT}")
+    set(abs_pyf_file "${F2PY_OUTPUT}")
+  else()
+    set(abs_pyf_file "${CMAKE_CURRENT_BINARY_DIR}/${F2PY_OUTPUT}")
+  endif()
+
+  # Walk the arguments, absolutizing source files but passing f2py's skip:/only:
+  # routine selectors through untouched. A skip:/only: token opens a block of
+  # routine names that runs until a bare ":"; those names are not paths.
+  set(passthrough_args)
+  set(abs_source_files)
+  set(in_selector_block FALSE)
+  foreach(arg IN LISTS ALL_ARGS)
+    if(arg STREQUAL "skip:" OR arg STREQUAL "only:")
+      set(in_selector_block TRUE)
+      list(APPEND passthrough_args "${arg}")
+    elseif(arg STREQUAL ":")
+      set(in_selector_block FALSE)
+      list(APPEND passthrough_args "${arg}")
+    elseif(in_selector_block)
+      list(APPEND passthrough_args "${arg}")
+    elseif(IS_ABSOLUTE "${arg}")
+      list(APPEND passthrough_args "${arg}")
+      list(APPEND abs_source_files "${arg}")
+    else()
+      list(APPEND passthrough_args "${CMAKE_CURRENT_SOURCE_DIR}/${arg}")
+      list(APPEND abs_source_files "${CMAKE_CURRENT_SOURCE_DIR}/${arg}")
+    endif()
+  endforeach()
+
+  if(NOT abs_source_files)
+    message(FATAL_ERROR "One or more input files must be specified")
+  endif()
+
+  if(F2PY_NOLOWER)
+    set(lower "--no-lower")
+  else()
+    set(lower "--lower")
+  endif()
+
+  # --overwrite-signature is required: f2py refuses to replace an existing .pyf,
+  # which would break incremental rebuilds.
+  add_custom_command(
+    OUTPUT "${abs_pyf_file}"
+    DEPENDS ${abs_source_files}
+    VERBATIM
+    COMMAND
+      "${${_Python}_EXECUTABLE}" -m numpy.f2py
+      -h "${abs_pyf_file}" --overwrite-signature -m "${MODULE}"
+      ${passthrough_args} ${lower} "${F2PY_F2PY_ARGS}"
+    COMMAND_EXPAND_LISTS
+    COMMENT
+      "F2PY generating ${MODULE} signature"
+  )
+
+  set_source_files_properties("${abs_pyf_file}" PROPERTIES GENERATED TRUE)
+
+  if(F2PY_OUTPUT_VARIABLE)
+    set(${F2PY_OUTPUT_VARIABLE} "${abs_pyf_file}" PARENT_SCOPE)
+  endif()
+endfunction()
+
 function(f2py_generate_module NAME)
   cmake_parse_arguments(
     PARSE_ARGV 1
@@ -72,10 +148,7 @@ function(f2py_generate_module NAME)
     else()
       set(abs_pyf_file "${CMAKE_CURRENT_SOURCE_DIR}/${NAME}")
     endif()
-    set(_file_arg "${abs_pyf_file}")
     get_filename_component(NAME "${NAME}" NAME_WE)
-  else()
-    set(_file_arg -m ${NAME})
   endif()
 
   if(F2PY_F77 AND F2PY_F90)
@@ -124,13 +197,23 @@ function(f2py_generate_module NAME)
     endif()
   endforeach()
 
+  # A signature file fully specifies the interface, so f2py reads only it; the
+  # sources are compiled and linked separately (via OUTPUT_VARIABLE). Mixing the
+  # two on the command line makes f2py reject the bare-subroutine source blocks.
+  # Without a signature, f2py reads the sources directly to wrap module NAME.
+  if(abs_pyf_file)
+    set(f2py_inputs "${abs_pyf_file}")
+  else()
+    set(f2py_inputs ${abs_all_files} -m ${NAME})
+  endif()
+
   add_custom_command(
     OUTPUT ${module_output} ${abs_wrapper_files}
     DEPENDS ${abs_all_files} ${abs_pyf_file}
     VERBATIM
     COMMAND
       "${${_Python}_EXECUTABLE}" -m numpy.f2py
-      "${abs_all_files}" "${_file_arg}" ${lower} "${F2PY_F2PY_ARGS}"
+      ${f2py_inputs} ${lower} "${F2PY_F2PY_ARGS}"
     COMMAND_EXPAND_LISTS
     COMMAND
       "${CMAKE_COMMAND}" -E touch ${abs_wrapper_files}

--- a/tests/packages/sig/CMakeLists.txt
+++ b/tests/packages/sig/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.15...3.29)
+project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
+
+find_package(
+  Python
+  COMPONENTS Interpreter Development.Module NumPy
+  REQUIRED)
+
+include(UseF2Py)
+
+f2py_object_library(f2py_object OBJECT)
+
+# Generate a signature that wraps only keep_me, then build the module from it.
+f2py_generate_signature(mymod mymod.f90 "skip:" drop_me ":"
+                        OUTPUT mymod.pyf OUTPUT_VARIABLE mymod_sig)
+
+f2py_generate_module(${mymod_sig} mymod.f90 OUTPUT_VARIABLE mymod_files)
+
+python_add_library(mymod MODULE "${mymod_files}" WITH_SOABI)
+target_link_libraries(mymod PRIVATE f2py_object)
+
+install(TARGETS mymod DESTINATION .)

--- a/tests/packages/sig/CMakeLists.txt
+++ b/tests/packages/sig/CMakeLists.txt
@@ -11,7 +11,8 @@ include(UseF2Py)
 f2py_object_library(f2py_object OBJECT)
 
 # Generate a signature that wraps only keep_me, then build the module from it.
-f2py_generate_signature(mymod mymod.f90 "skip:" drop_me ":"
+f2py_generate_signature(mymod mymod.f90
+                        SKIP drop_me
                         OUTPUT mymod.pyf OUTPUT_VARIABLE mymod_sig)
 
 f2py_generate_module(${mymod_sig} mymod.f90 OUTPUT_VARIABLE mymod_files)

--- a/tests/packages/sig/mymod.f90
+++ b/tests/packages/sig/mymod.f90
@@ -1,0 +1,9 @@
+subroutine keep_me(a)
+   real*8, intent(out) :: a
+   a = 1.0d0
+end subroutine keep_me
+
+subroutine drop_me(a)
+   real*8, intent(out) :: a
+   a = 2.0d0
+end subroutine drop_me

--- a/tests/packages/sig/pyproject.toml
+++ b/tests/packages/sig/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["scikit-build-core", "numpy", "f2py-cmake"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "example"
+version = "0.0.1"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -40,6 +40,22 @@ def test_f77(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(CMAKE is None, reason="CMake not found")
+def test_signature(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(DIR / "packages/sig")
+    build_dir = tmp_path / "build"
+
+    build_wheel(str(tmp_path), {"build-dir": str(build_dir), "wheel.license-files": []})
+
+    build_files = {x.name for x in build_dir.iterdir()}
+    assert "mymod.pyf" in build_files
+    assert "mymodmodule.c" in build_files
+
+    signature = (build_dir / "mymod.pyf").read_text()
+    assert "keep_me" in signature
+    assert "drop_me" not in signature
+
+
+@pytest.mark.skipif(CMAKE is None, reason="CMake not found")
 def test_f90(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     assert CMAKE is not None
     src_dir = tmp_path / "source"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #6.

Adds a signature-generation step to `UseF2Py.cmake`, following the
investigation in #6 (proposal posted [there](https://github.com/scikit-build/f2py-cmake/issues/6#issuecomment-4774397242)).

## What's new

`f2py_generate_signature()` produces a `.pyf` from Fortran sources, which
`f2py_generate_module()` already knows how to consume as its `<module>`
argument:

```cmake
f2py_generate_signature(mymod a.f90 b.f90
                        ONLY public_api          # or: SKIP drop_me
                        OUTPUT mymod.pyf OUTPUT_VARIABLE mymod_sig)
f2py_generate_module(${mymod_sig} a.f90 b.f90 OUTPUT_VARIABLE mymod_files)
```

`ONLY`/`SKIP` are native CMake multi-value keyword arguments that restrict which
routines are wrapped; they translate internally to f2py's `only: <names> :` /
`skip: <names> :` selector blocks. `--overwrite-signature` is always passed so
incremental rebuilds work.

Out of scope (per the proposal): sisl's `WITH_F_WRAPPER`/`WITH_F90_WRAPPER`,
already handled here by the `F77`/`F90` override plus `cmake -E touch`.

## Bug fix

The `.pyf` branch of `f2py_generate_module()` was untested and broken: it
passed both the signature **and** the source files to f2py, which rejects the
mix (`All blocks must be python module blocks but got 'subroutine'`). The
signature now defines the interface and the sources are only compiled/linked
(via `OUTPUT_VARIABLE`). The non-signature path is unchanged.

## Tests

New `tests/packages/sig/` fixture + `test_signature`: builds a wheel and
asserts the generated `.pyf` wraps `keep_me` but not the `SKIP`-ped `drop_me`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
