### PR TITLE
docs: show signature/link source decoupling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,7 @@ Thumbs.db
 # Symlink to AGENTS.md
 CLAUDE.md
 .claude
+
+# Lockfiles
+uv.lock
+*pylock*

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ exposed to Python:
 f2py_generate_signature(mymod a.f90 OUTPUT mymod.pyf OUTPUT_VARIABLE mymod_sig)
 
 # helper.f90 is linked but not wrapped.
-f2py_generate_module(${mymod_sig} a.f90 helper.f90 OUTPUT_VARIABLE mymod_files)
+f2py_generate_module("${mymod_sig}" a.f90 helper.f90 OUTPUT_VARIABLE mymod_files)
 ```
 
 ## scikit-build-core

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ python_add_library(mymod MODULE "${mymod_files}" WITH_SOABI)
 target_link_libraries(mymod PRIVATE f2py_object)
 ```
 
+The files passed to `f2py_generate_module` need not match those used for the
+signature. The signature alone defines the wrapped interface, so you can build
+it from a subset and link extra Fortran that is called internally but never
+exposed to Python:
+
+```cmake
+f2py_generate_signature(mymod a.f90 OUTPUT mymod.pyf OUTPUT_VARIABLE mymod_sig)
+
+# helper.f90 is linked but not wrapped.
+f2py_generate_module(${mymod_sig} a.f90 helper.f90 OUTPUT_VARIABLE mymod_files)
+```
+
 ## scikit-build-core
 
 To use this package with scikit-build-core, you need to include it in your build

--- a/tests/packages/sig/CMakeLists.txt
+++ b/tests/packages/sig/CMakeLists.txt
@@ -10,12 +10,14 @@ include(UseF2Py)
 
 f2py_object_library(f2py_object OBJECT)
 
-# Generate a signature that wraps only keep_me, then build the module from it.
+# The signature is generated from mymod.f90 alone and wraps only keep_me.
 f2py_generate_signature(mymod mymod.f90
                         SKIP drop_me
                         OUTPUT mymod.pyf OUTPUT_VARIABLE mymod_sig)
 
-f2py_generate_module(${mymod_sig} mymod.f90 OUTPUT_VARIABLE mymod_files)
+# The module is built from that signature, but helper.f90 is linked in too: it
+# provides compute(), which keep_me calls but which is never wrapped.
+f2py_generate_module(${mymod_sig} mymod.f90 helper.f90 OUTPUT_VARIABLE mymod_files)
 
 python_add_library(mymod MODULE "${mymod_files}" WITH_SOABI)
 target_link_libraries(mymod PRIVATE f2py_object)

--- a/tests/packages/sig/helper.f90
+++ b/tests/packages/sig/helper.f90
@@ -1,0 +1,6 @@
+! Linked into the extension but absent from the signature: keep_me calls it,
+! yet it is never exposed to Python.
+subroutine compute(a)
+   real*8, intent(out) :: a
+   a = 42.0d0
+end subroutine compute

--- a/tests/packages/sig/mymod.f90
+++ b/tests/packages/sig/mymod.f90
@@ -1,6 +1,6 @@
 subroutine keep_me(a)
    real*8, intent(out) :: a
-   a = 1.0d0
+   call compute(a)
 end subroutine keep_me
 
 subroutine drop_me(a)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -53,6 +53,8 @@ def test_signature(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     signature = (build_dir / "mymod.pyf").read_text()
     assert "keep_me" in signature
     assert "drop_me" not in signature
+    # helper.f90 is linked but not part of the signature.
+    assert "compute" not in signature
 
 
 @pytest.mark.skipif(CMAKE is None, reason="CMake not found")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Followup to #54 (the last remaining item from #6).

Building a signature from a *subset* of sources while linking extra Fortran
that is called internally but never wrapped already works — `f2py_generate_module`
reads only the `.pyf` for the interface and links whatever sources you pass it.
This documents the pattern and proves it in the fixture.

```cmake
f2py_generate_signature(mymod a.f90 OUTPUT mymod.pyf OUTPUT_VARIABLE mymod_sig)

# helper.f90 is linked but not wrapped.
f2py_generate_module(${mymod_sig} a.f90 helper.f90 OUTPUT_VARIABLE mymod_files)
```

The `sig` fixture now adds `helper.f90` with a `compute()` routine that
`keep_me` calls; the signature is generated from `mymod.f90` alone.
`test_signature` additionally asserts `compute` is absent from the generated
`.pyf`.

No API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
