### PR TITLE
test: cover Fortran module calling a separate C library (#20)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = [
   "error",
+  # f2py modules don't declare free-threading support, so a free-threaded
+  # interpreter warns when re-enabling the GIL to import one.
+  "ignore:The global interpreter lock:RuntimeWarning",
 ]
 log_level = "INFO"
 testpaths = [

--- a/tests/packages/cmix/CMakeLists.txt
+++ b/tests/packages/cmix/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.15...3.29)
+project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
+
+find_package(
+  Python
+  COMPONENTS Interpreter Development.Module NumPy
+  REQUIRED)
+
+include(UseF2Py)
+
+# A separate C library the Fortran routine calls into (issue #20).
+add_library(adder STATIC adder.c)
+set_property(TARGET adder PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+f2py_object_library(f2py_object OBJECT)
+
+f2py_generate_module(mixed mixed.f90 OUTPUT_VARIABLE mixed_files)
+
+python_add_library(mixed MODULE "${mixed_files}" WITH_SOABI)
+target_link_libraries(mixed PRIVATE f2py_object adder)
+
+install(TARGETS mixed DESTINATION .)

--- a/tests/packages/cmix/adder.c
+++ b/tests/packages/cmix/adder.c
@@ -1,0 +1,5 @@
+/* C routine called from Fortran, exposed under a fixed name for bind(C).
+   Lives in a separate library to mirror issue #20 (Fortran calling into C). */
+double add_in_c(double a, double b) {
+  return a + b;
+}

--- a/tests/packages/cmix/mixed.f90
+++ b/tests/packages/cmix/mixed.f90
@@ -1,0 +1,17 @@
+! f2py-wrapped Fortran that calls a C routine from a separate library.
+! Without the original source compiled into the module (or the C library
+! linked), importing this fails with an undefined symbol (issue #20).
+subroutine add_them(a, b, c)
+  use iso_c_binding, only: c_double
+  implicit none
+  real(c_double), intent(in) :: a, b
+  real(c_double), intent(out) :: c
+  interface
+    function add_in_c(x, y) bind(c, name="add_in_c") result(r)
+      use iso_c_binding, only: c_double
+      real(c_double), value :: x, y
+      real(c_double) :: r
+    end function add_in_c
+  end interface
+  c = add_in_c(a, b)
+end subroutine add_them

--- a/tests/packages/cmix/mixed.f90
+++ b/tests/packages/cmix/mixed.f90
@@ -2,10 +2,11 @@
 ! Without the original source compiled into the module (or the C library
 ! linked), importing this fails with an undefined symbol (issue #20).
 subroutine add_them(a, b, c)
-  use iso_c_binding, only: c_double
   implicit none
-  real(c_double), intent(in) :: a, b
-  real(c_double), intent(out) :: c
+  ! Plain double precision in the wrapped signature: older f2py maps the
+  ! iso_c_binding c_double kind to C float, which silently corrupts results.
+  double precision, intent(in) :: a, b
+  double precision, intent(out) :: c
   interface
     function add_in_c(x, y) bind(c, name="add_in_c") result(r)
       use iso_c_binding, only: c_double

--- a/tests/packages/cmix/pyproject.toml
+++ b/tests/packages/cmix/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["scikit-build-core", "numpy", "f2py-cmake"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "example"
+version = "0.0.1"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -56,6 +56,31 @@ def test_signature(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(CMAKE is None, reason="CMake not found")
+def test_cmix(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # A Fortran module that calls into a separate C library (issue #20). The
+    # original source must be compiled in and the C library linked, or the
+    # built module fails to import with an undefined symbol. Building isn't
+    # enough to catch this on macOS (-undefined dynamic_lookup), so import it.
+    monkeypatch.chdir(DIR / "packages/cmix")
+    build_dir = tmp_path / "build"
+
+    wheel = build_wheel(
+        str(tmp_path), {"build-dir": str(build_dir), "wheel.license-files": []}
+    )
+
+    install_dir = tmp_path / "install"
+    with zipfile.ZipFile(tmp_path / wheel) as f:
+        f.extractall(install_dir)
+
+    monkeypatch.syspath_prepend(str(install_dir))
+    try:
+        mixed = importlib.import_module("mixed")
+        assert mixed.add_them(2.0, 3.0) == pytest.approx(5.0)
+    finally:
+        sys.modules.pop("mixed", None)
+
+
+@pytest.mark.skipif(CMAKE is None, reason="CMake not found")
 def test_f90(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     assert CMAKE is not None
     src_dir = tmp_path / "source"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What

Adds a test fixture (`tests/packages/cmix/`) modeled on issue #20: an f2py module whose Fortran source calls into a **separately-linked C library** (`add_library(adder ...)` linked via `target_link_libraries`). The test builds a wheel, extracts it, **imports the module**, and asserts `add_them(2.0, 3.0) == 5.0`.

## Why

The existing fixtures are all pure Fortran linked only to `f2py_object`, and none of them import a built module — `test_f77`/`test_signature` only assert files exist in the wheel, and `test_f90` only configures. That leaves two things untested:

1. The Fortran-calls-external-C-library link pattern (the part of #20 the reporter was unsure about).
2. Runtime symbol resolution. On macOS, Python extensions link with `-undefined dynamic_lookup`, so a missing symbol builds cleanly and only fails at `import` — exactly the `ImportError: dlopen ... symbol not found` in #20.

I verified this is a real guard: reintroducing the pre-#53 bug (dropping the original sources from `f2py_generate_module`'s `OUTPUT_VARIABLE`) makes the test fail with that exact import error **while the build still succeeds**, which build-only checks would never catch.

## Also

Moves the free-threading GIL `RuntimeWarning` filter into `pyproject.toml`'s `filterwarnings` (f2py modules don't declare free-threading support, so importing one under a free-threaded interpreter re-enables the GIL and warns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)