### PR TITLE
docs: remove undefined F2Py::F2Py target and F2PY_EXECUTABLE from docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,10 @@ Two distinct distribution paths feed off the same `UseF2Py.cmake` file:
    the bundled CMake file. There is no templating — it is a verbatim copy, which
    `tests/test_vendorize.py` asserts byte-for-byte.
 
-`UseF2Py.cmake` defines the public CMake API: the `F2Py::Headers` / `F2Py::F2Py`
-targets, `f2py_object_library()`, and `f2py_generate_module()`. It auto-detects
-whether `Python` or `Python3` was found (requiring the NumPy component) and
-shells out to `numpy.f2py.get_include()` to locate `fortranobject.c/.h`.
+`UseF2Py.cmake` defines the public CMake API: the `F2Py::Headers` target,
+`f2py_object_library()`, and `f2py_generate_module()`. It auto-detects whether
+`Python` or `Python3` was found (requiring the NumPy component) and shells out
+to `numpy.f2py.get_include()` to locate `fortranobject.c/.h`.
 `f2py_generate_module()` auto-selects F77 vs F90 from file extensions unless
 `F77`/`F90` is passed; this controls which f2py wrapper files
 (`*-f2pywrappers.f`, `*-f2pywrappers2.f90`) are declared as build outputs.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ include(UseF2Py)
 ```
 
 You must have found a Python interpreter beforehand. This will define a
-`F2Py::F2Py` target (along with a matching `F2PY_EXECUTABLE` variable). It will
-also provide the following helper functions:
+`F2Py::Headers` target and provide the following helper functions:
 
 ```cmake
 f2py_object_library(<name> <type>)


### PR DESCRIPTION
This was never added since you can do `python -m numpy.f2py`, and we can't ensure we always find the helper.

:robot: _AI text below_ :robot:

The README and `AGENTS.md` claimed that `include(UseF2Py)` defines a `F2Py::F2Py` target along with a matching `F2PY_EXECUTABLE` variable. Neither exists: `UseF2Py.cmake` only defines `F2Py::Headers`. This removes those false claims rather than implementing them.

- `README.md`: the intro now states that `include(UseF2Py)` defines a `F2Py::Headers` target and provides the helper functions.
- `AGENTS.md`: dropped `F2Py::F2Py` from the list of defined targets (the `CLAUDE.md` symlink points at `AGENTS.md`, so it is covered too).

Docs-only change; `UseF2Py.cmake` is untouched.

Addresses item #1 of #57.