### PR TITLE
fix: detect free-form Fortran extensions case-insensitively

### DIFF
--- a/src/f2py_cmake/cmake/UseF2Py.cmake
+++ b/src/f2py_cmake/cmake/UseF2Py.cmake
@@ -151,8 +151,11 @@ function(f2py_generate_module NAME)
   elseif(NOT F2PY_F77 AND NOT F2PY_F90)
     set(HAS_F90_FILE FALSE)
 
+    # Free-form Fortran (.f90 and later) generates a -f2pywrappers2.f90 wrapper;
+    # fixed-form F77 (.f/.F) does not. Lowercase first so .F90, .F95, etc. match.
     foreach(file IN LISTS ALL_FILES)
-        if("${file}" MATCHES "\\.f90$")
+        string(TOLOWER "${file}" file_lower)
+        if("${file_lower}" MATCHES "\\.(f90|f95|f03|f08|f15|f18)$")
             set(HAS_F90_FILE TRUE)
             break()
         endif()

--- a/tests/packages/f90dual/src/CMakeLists.txt
+++ b/tests/packages/f90dual/src/CMakeLists.txt
@@ -12,6 +12,11 @@ message(STATUS "Building test f2py module")
 
 f2py_object_library(test_object OBJECT)
 f2py_generate_module(test_ test_py.F90 OUTPUT_VARIABLE test_files)
+# .F90 is free-form Fortran: auto-detection must select the F90 path and declare
+# the -f2pywrappers2.f90 output despite the uppercase extension (gh-57 item 2).
+if(NOT test_files MATCHES "test_-f2pywrappers2\\.f90")
+  message(FATAL_ERROR "Expected F90 wrapper for .F90 source, got: ${test_files}")
+endif()
 python_add_library(test_ MODULE "${test_files}" WITH_SOABI)
 target_link_libraries(test_ PRIVATE test_object)
 install(TARGETS test_ DESTINATION lib/Python)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Addresses item #2 of #57.

## Problem

In `src/f2py_cmake/cmake/UseF2Py.cmake`, `f2py_generate_module` auto-selects the F90 vs F77 path by matching each input against `\.f90$`. CMake regex matching is **case-sensitive**, so `.F90`, `.f95`, `.f03`, `.f08`, and other free-form modern Fortran extensions fail to match and silently fall through to the F77 branch. The F77 branch only declares `*-f2pywrappers.f` as a build output and omits the `*-f2pywrappers2.f90` wrapper that free-form code generates, producing silently-wrong build outputs.

## Fix

Lowercase the filename with `string(TOLOWER ...)` before matching, and match against the set of free-form extensions: `.f90 .f95 .f03 .f08 .f15 .f18` (and their uppercase / preprocessed forms). Fixed-form `.f`/`.F` (F77) continue to select F77. The explicit `F77`/`F90` override arguments are unchanged and still win.

`string(TOLOWER ...)` is available in CMake 3.17, so minimum-version compatibility is preserved.

## Tests

The `f90dual` fixture already uses uppercase `.F90` sources. Added a configure-time assertion in `tests/packages/f90dual/src/CMakeLists.txt` that the detected outputs include `test_-f2pywrappers2.f90`. Verified this assertion fails against the old code and passes with the fix. Full suite: `5 passed`. Lint clean via `prek -a`.