### PR TITLE
feat: add f2py_add_module one-shot helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ include(UseF2Py)
 f2py_add_module(fibby fib1.f)
 ```
 
+`<name>` may instead be a `.pyf` signature path (as accepted by
+`f2py_generate_module`); the module name is taken from the file stem. The
+created target is a normal CMake target named `<name>`, so customize it
+afterward with `target_*()` / `set_target_properties()` as usual.
+
 If you need to share a single `fortranobject` library across several modules, or
 want the generated sources for custom wiring, use the primitives directly:
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,20 @@ f2py_generate_module(<module> <files>...
                   [OUTPUT_DIR <OutputDir>]
                   [OUTPUT_VARIABLE <OutputVariable>]
                   )
+
+f2py_add_module(<name> <files>...
+                  [F2PY_ARGS <args> ...]
+                  [F77 | F90]
+                  [NOLOWER]
+                  [OUTPUT_DIR <OutputDir>]
+                  )
 ```
 
 ## Example
+
+`f2py_add_module` builds an importable extension module in a single call. It
+generates the wrappers, creates the Python module target, and compiles/links the
+F2Py `fortranobject` support for you:
 
 ```cmake
 find_package(
@@ -56,6 +67,13 @@ find_package(
 
 include(UseF2Py)
 
+f2py_add_module(fibby fib1.f)
+```
+
+If you need to share a single `fortranobject` library across several modules, or
+want the generated sources for custom wiring, use the primitives directly:
+
+```cmake
 # Create the F2Py `numpyobject` library.
 f2py_object_library(f2py_object OBJECT)
 

--- a/src/f2py_cmake/cmake/UseF2Py.cmake
+++ b/src/f2py_cmake/cmake/UseF2Py.cmake
@@ -225,3 +225,60 @@ function(f2py_generate_module NAME)
                                 PARENT_SCOPE)
   endif()
 endfunction()
+
+# One-shot helper: generate the f2py wrappers, build the Python extension
+# module, and compile/link fortranobject in one call. This is sugar over
+# f2py_object_library + f2py_generate_module + python_add_library; reach for the
+# primitives directly when sharing a single fortranobject library across modules
+# or when you need OUTPUT_VARIABLE for custom wiring. The pass-through options
+# match f2py_generate_module.
+function(f2py_add_module NAME)
+  cmake_parse_arguments(
+    PARSE_ARGV 1
+    F2PY
+    "NOLOWER;F77;F90"
+    "OUTPUT_DIR"
+    "F2PY_ARGS"
+  )
+
+  # Forward the parsed options back through to f2py_generate_module. Each option
+  # is only added when it was set so f2py_generate_module's own defaults apply.
+  set(generate_args)
+  if(F2PY_F77)
+    list(APPEND generate_args F77)
+  endif()
+  if(F2PY_F90)
+    list(APPEND generate_args F90)
+  endif()
+  if(F2PY_NOLOWER)
+    list(APPEND generate_args NOLOWER)
+  endif()
+  if(F2PY_OUTPUT_DIR)
+    list(APPEND generate_args OUTPUT_DIR "${F2PY_OUTPUT_DIR}")
+  endif()
+  if(F2PY_F2PY_ARGS)
+    list(APPEND generate_args F2PY_ARGS ${F2PY_F2PY_ARGS})
+  endif()
+
+  f2py_generate_module(${NAME} ${F2PY_UNPARSED_ARGUMENTS}
+                       ${generate_args} OUTPUT_VARIABLE ${NAME}_files)
+
+  # A pyf module argument carries the .pyf path; strip it to the real module
+  # name so the target and library names match f2py_generate_module's output.
+  if(NAME MATCHES "\\.pyf$")
+    get_filename_component(NAME "${NAME}" NAME_WE)
+  endif()
+
+  # ${_Python} is Python or Python3; the matching <Python>_add_library command
+  # can't be named through a variable, so dispatch on it explicitly.
+  if(_Python STREQUAL "Python")
+    Python_add_library(${NAME} MODULE "${${NAME}_files}" WITH_SOABI)
+  else()
+    Python3_add_library(${NAME} MODULE "${${NAME}_files}" WITH_SOABI)
+  endif()
+
+  # Compile fortranobject into a private per-module object library; the unique
+  # name avoids collisions when f2py_add_module is called for several modules.
+  f2py_object_library(${NAME}_f2py_object OBJECT)
+  target_link_libraries(${NAME} PRIVATE ${NAME}_f2py_object)
+endfunction()

--- a/src/f2py_cmake/cmake/UseF2Py.cmake
+++ b/src/f2py_cmake/cmake/UseF2Py.cmake
@@ -260,25 +260,30 @@ function(f2py_add_module NAME)
     list(APPEND generate_args F2PY_ARGS ${F2PY_F2PY_ARGS})
   endif()
 
-  f2py_generate_module(${NAME} ${F2PY_UNPARSED_ARGUMENTS}
-                       ${generate_args} OUTPUT_VARIABLE ${NAME}_files)
-
   # A pyf module argument carries the .pyf path; strip it to the real module
-  # name so the target and library names match f2py_generate_module's output.
-  if(NAME MATCHES "\\.pyf$")
-    get_filename_component(NAME "${NAME}" NAME_WE)
+  # name so the target/library names and the OUTPUT_VARIABLE we read back match
+  # f2py_generate_module's output. The .pyf path itself is still passed through
+  # to f2py_generate_module, which strips it the same way internally.
+  set(MODULE_NAME "${NAME}")
+  if(MODULE_NAME MATCHES "\\.pyf$")
+    get_filename_component(MODULE_NAME "${MODULE_NAME}" NAME_WE)
   endif()
 
+  f2py_generate_module(${NAME} ${F2PY_UNPARSED_ARGUMENTS}
+                       ${generate_args} OUTPUT_VARIABLE ${MODULE_NAME}_files)
+
   # ${_Python} is Python or Python3; the matching <Python>_add_library command
-  # can't be named through a variable, so dispatch on it explicitly.
+  # can't be named through a variable, so dispatch on it explicitly. Only MODULE
+  # type and WITH_SOABI matter here; USE_SABI (limited ABI) doesn't apply because
+  # the generated module and fortranobject use the full CPython/NumPy C API.
   if(_Python STREQUAL "Python")
-    Python_add_library(${NAME} MODULE "${${NAME}_files}" WITH_SOABI)
+    Python_add_library(${MODULE_NAME} MODULE "${${MODULE_NAME}_files}" WITH_SOABI)
   else()
-    Python3_add_library(${NAME} MODULE "${${NAME}_files}" WITH_SOABI)
+    Python3_add_library(${MODULE_NAME} MODULE "${${MODULE_NAME}_files}" WITH_SOABI)
   endif()
 
   # Compile fortranobject into a private per-module object library; the unique
   # name avoids collisions when f2py_add_module is called for several modules.
-  f2py_object_library(${NAME}_f2py_object OBJECT)
-  target_link_libraries(${NAME} PRIVATE ${NAME}_f2py_object)
+  f2py_object_library(${MODULE_NAME}_f2py_object OBJECT)
+  target_link_libraries(${MODULE_NAME} PRIVATE ${MODULE_NAME}_f2py_object)
 endfunction()

--- a/tests/packages/addmodule/CMakeLists.txt
+++ b/tests/packages/addmodule/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.15...3.29)
+project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
+
+find_package(
+  Python
+  COMPONENTS Interpreter Development.Module NumPy
+  REQUIRED)
+
+include(UseF2Py)
+
+f2py_add_module(fibby fib1.f)
+
+install(TARGETS fibby DESTINATION .)

--- a/tests/packages/addmodule/fib1.f
+++ b/tests/packages/addmodule/fib1.f
@@ -1,0 +1,18 @@
+C FILE: FIB1.F
+      SUBROUTINE FIB(A,N)
+C
+C     CALCULATE FIRST N FIBONACCI NUMBERS
+C
+      INTEGER N
+      REAL*8 A(N)
+      DO I=1,N
+         IF (I.EQ.1) THEN
+            A(I) = 0.0D0
+         ELSEIF (I.EQ.2) THEN
+            A(I) = 1.0D0
+         ELSE
+            A(I) = A(I-1) + A(I-2)
+         ENDIF
+      ENDDO
+      END
+C END FILE FIB1.F

--- a/tests/packages/addmodule/pyproject.toml
+++ b/tests/packages/addmodule/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["scikit-build-core", "numpy", "f2py-cmake"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "example"
+version = "0.0.1"

--- a/tests/packages/addmodulepyf/CMakeLists.txt
+++ b/tests/packages/addmodulepyf/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.15...3.29)
+project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
+
+find_package(
+  Python
+  COMPONENTS Interpreter Development.Module NumPy
+  REQUIRED)
+
+include(UseF2Py)
+
+# Drive the one-shot helper from a checked-in signature file. The .pyf path is
+# stripped to the real module name (mymod) for the target and library.
+f2py_add_module(mymod.pyf mymod.f90)
+
+install(TARGETS mymod DESTINATION .)

--- a/tests/packages/addmodulepyf/mymod.f90
+++ b/tests/packages/addmodulepyf/mymod.f90
@@ -1,0 +1,9 @@
+subroutine keep_me(a)
+   real*8, intent(out) :: a
+   a = 1.0d0
+end subroutine keep_me
+
+subroutine drop_me(a)
+   real*8, intent(out) :: a
+   a = 2.0d0
+end subroutine drop_me

--- a/tests/packages/addmodulepyf/mymod.pyf
+++ b/tests/packages/addmodulepyf/mymod.pyf
@@ -1,0 +1,10 @@
+!    -*- f90 -*-
+! Note: the context of this file is case sensitive.
+
+python module mymod ! in
+    interface  ! in :mymod
+        subroutine keep_me(a) ! in :mymod:mymod.f90
+            real*8 intent(out) :: a
+        end subroutine keep_me
+    end interface
+end python module mymod

--- a/tests/packages/addmodulepyf/pyproject.toml
+++ b/tests/packages/addmodulepyf/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["scikit-build-core", "numpy", "f2py-cmake"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "example"
+version = "0.0.1"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -58,6 +58,17 @@ def test_add_module(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(CMAKE is None, reason="CMake not found")
+def test_add_module_pyf(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(DIR / "packages/addmodulepyf")
+    build_dir = tmp_path / "build"
+
+    build_wheel(str(tmp_path), {"build-dir": str(build_dir), "wheel.license-files": []})
+
+    build_files = {x.name for x in build_dir.iterdir()}
+    assert "mymodmodule.c" in build_files
+
+
+@pytest.mark.skipif(CMAKE is None, reason="CMake not found")
 def test_signature(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.chdir(DIR / "packages/sig")
     build_dir = tmp_path / "build"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -40,6 +40,24 @@ def test_f77(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(CMAKE is None, reason="CMake not found")
+def test_add_module(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(DIR / "packages/addmodule")
+    build_dir = tmp_path / "build"
+
+    wheel = build_wheel(
+        str(tmp_path), {"build-dir": str(build_dir), "wheel.license-files": []}
+    )
+
+    with zipfile.ZipFile(tmp_path / wheel) as f:
+        file_names = set(f.namelist())
+    assert len(file_names) == 4
+
+    build_files = {x.name for x in build_dir.iterdir()}
+    assert "fibbymodule.c" in build_files
+    assert "fibby-f2pywrappers.f" in build_files
+
+
+@pytest.mark.skipif(CMAKE is None, reason="CMake not found")
 def test_signature(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.chdir(DIR / "packages/sig")
     build_dir = tmp_path / "build"


### PR DESCRIPTION
I'm not sure about this - I don't like wrapping python_add_library, since it has arguments you might want to pass.

:robot: _AI text below_ :robot:

Addresses item #5 of #57.

## What

Adds `f2py_add_module(<name> <files>... [options])`, a one-shot convenience helper that collapses the four manual steps users wire by hand today into a single call:

```cmake
include(UseF2Py)

f2py_add_module(fibby fib1.f)
```

Previously this required:

```cmake
f2py_object_library(f2py_object OBJECT)
f2py_generate_module(fibby fib1.f OUTPUT_VARIABLE fibby_files)
python_add_library(fibby MODULE "${fibby_files}" WITH_SOABI)
target_link_libraries(fibby PRIVATE f2py_object)
```

## Details

- Internally calls `f2py_generate_module(... OUTPUT_VARIABLE ...)`, creates the module target via `Python_add_library` / `Python3_add_library` (dispatched on the detected `_Python`, since a command name can't be variable-expanded in CMake), then compiles/links a private per-module `fortranobject` object library.
- The internal object library is named from `<name>` so multiple `f2py_add_module` calls don't collide on target names.
- Forwards the same pass-through options as `f2py_generate_module`: `F77 | F90`, `NOLOWER`, `OUTPUT_DIR`, `F2PY_ARGS`. `OUTPUT_VARIABLE` is intentionally not supported (the function owns the target).
- The existing primitives (`f2py_object_library`, `f2py_generate_module`) are unchanged and remain public for sharing a single `fortranobject` library across modules or for custom wiring.
- Keeps CMake 3.17 compatibility.

## Docs & tests

- README: added the signature to the helper block and a one-call usage section, with the verbose four-step form retained as the "share/customize" path.
- Added a `tests/packages/addmodule/` fixture (single `.f` file, `f2py_add_module`) and `test_add_module` in `tests/test_package.py`, modeled on `test_f77`. Auto-skips when cmake is absent.

Local `uv run pytest` (6 passed) and `prek -a --quiet` both pass.