### PR TITLE
chore: bump to Beta and use dependency-groups for hatch-test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 license.file = "LICENSE"
 requires-python = ">=3.8"
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Science/Research",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
@@ -65,7 +65,7 @@ build.hooks.vcs.version-file = "src/f2py_cmake/_version.py"
 installer = "uv"
 
 [tool.hatch.envs.hatch-test]
-features = ["test"]
+dependency-groups = ["test"]
 extra-dependencies = ["cmake", "ninja"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Two small packaging updates:

- Promote the development status classifier from `3 - Alpha` to `4 - Beta`.
- Point the `hatch-test` environment at the existing `[dependency-groups]` table via `dependency-groups = ["test"]` instead of the legacy `features = ["test"]` mechanism.