### PR TITLE
feat: support .f2py_f2cmap custom type maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ f2py_generate_signature(<module> <files>...
                   [ONLY <functions> ...]
                   [SKIP <functions> ...]
                   [OUTPUT_VARIABLE <OutputVariable>]
+                  [F2CMAP <file>]
                   [NOLOWER]
                   [F2PY_ARGS <args> ...]
                   )
@@ -40,6 +41,7 @@ f2py_generate_module(<module> <files>...
                   [F2PY_ARGS <args> ...]
                   [F77 | F90]
                   [NOLOWER]
+                  [F2CMAP <file>]
                   [OUTPUT_DIR <OutputDir>]
                   [OUTPUT_VARIABLE <OutputVariable>]
                   )
@@ -117,6 +119,29 @@ f2py_generate_signature(mymod a.f90 OUTPUT mymod.pyf OUTPUT_VARIABLE mymod_sig)
 # helper.f90 is linked but not wrapped.
 f2py_generate_module("${mymod_sig}" a.f90 helper.f90 OUTPUT_VARIABLE mymod_files)
 ```
+
+## Custom type maps
+
+Fortran code that uses custom kinds (such as `real(kind=dp)`) needs a
+`.f2py_f2cmap` file telling f2py how to map those kinds to C types, e.g.:
+
+```python
+dict(real=dict(dp="double"))
+```
+
+A `.f2py_f2cmap` placed next to your sources is auto-detected by both
+`f2py_generate_signature` and `f2py_generate_module`. You can also point at one
+explicitly with `F2CMAP <file>` (a relative path is resolved against the current
+source directory, and an explicit `F2CMAP` overrides auto-detection):
+
+```cmake
+f2py_generate_module(mymod mymod.f90 F2CMAP maps/types.f2cmap
+                     OUTPUT_VARIABLE mymod_files)
+```
+
+f2py's own `--f2cmap` default (the cwd) does not work here: these helpers run
+f2py in the build directory, not the source tree, so the file must be located
+explicitly.
 
 ## scikit-build-core
 

--- a/src/f2py_cmake/cmake/UseF2Py.cmake
+++ b/src/f2py_cmake/cmake/UseF2Py.cmake
@@ -52,7 +52,7 @@ function(f2py_generate_signature MODULE)
     PARSE_ARGV 1
     F2PY
     "NOLOWER"
-    "OUTPUT;OUTPUT_VARIABLE"
+    "OUTPUT;OUTPUT_VARIABLE;F2CMAP"
     "F2PY_ARGS;SKIP;ONLY"
   )
   set(ALL_FILES ${F2PY_UNPARSED_ARGUMENTS})
@@ -80,6 +80,26 @@ function(f2py_generate_signature MODULE)
     endif()
   endforeach()
 
+  # Resolve the .f2py_f2cmap custom type map. We pass it explicitly because
+  # f2py's --f2cmap default looks in the cwd, which is the binary dir here, not
+  # the source tree where the file lives. An explicit F2CMAP wins; otherwise a
+  # .f2py_f2cmap next to the sources is auto-detected.
+  set(abs_f2cmap)
+  if(F2PY_F2CMAP)
+    if(IS_ABSOLUTE "${F2PY_F2CMAP}")
+      set(abs_f2cmap "${F2PY_F2CMAP}")
+    else()
+      set(abs_f2cmap "${CMAKE_CURRENT_SOURCE_DIR}/${F2PY_F2CMAP}")
+    endif()
+  elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.f2py_f2cmap")
+    set(abs_f2cmap "${CMAKE_CURRENT_SOURCE_DIR}/.f2py_f2cmap")
+  endif()
+
+  set(f2cmap_arg)
+  if(abs_f2cmap)
+    set(f2cmap_arg --f2cmap "${abs_f2cmap}")
+  endif()
+
   # Translate the ONLY/SKIP routine filters into f2py's "only: <names> :" /
   # "skip: <names> :" selector blocks (each runs until a bare ":").
   set(selectors)
@@ -100,12 +120,12 @@ function(f2py_generate_signature MODULE)
   # which would break incremental rebuilds.
   add_custom_command(
     OUTPUT "${abs_pyf_file}"
-    DEPENDS ${abs_source_files}
+    DEPENDS ${abs_source_files} ${abs_f2cmap}
     VERBATIM
     COMMAND
       "${${_Python}_EXECUTABLE}" -m numpy.f2py
       -h "${abs_pyf_file}" --overwrite-signature -m "${MODULE}"
-      ${abs_source_files} ${selectors} ${lower} "${F2PY_F2PY_ARGS}"
+      ${abs_source_files} ${selectors} ${lower} ${f2cmap_arg} "${F2PY_F2PY_ARGS}"
     COMMAND_EXPAND_LISTS
     COMMENT
       "F2PY generating ${MODULE} signature"
@@ -123,7 +143,7 @@ function(f2py_generate_module NAME)
     PARSE_ARGV 1
     F2PY
     "NOLOWER;F77;F90"
-    "OUTPUT_DIR;OUTPUT_VARIABLE"
+    "OUTPUT_DIR;OUTPUT_VARIABLE;F2CMAP"
     "F2PY_ARGS"
   )
   set(ALL_FILES ${F2PY_UNPARSED_ARGUMENTS})
@@ -195,6 +215,26 @@ function(f2py_generate_module NAME)
     endif()
   endforeach()
 
+  # Resolve the .f2py_f2cmap custom type map. We pass it explicitly because
+  # f2py's --f2cmap default looks in the cwd, which is OUTPUT_DIR (the binary
+  # dir) here, not the source tree where the file lives. An explicit F2CMAP
+  # wins; otherwise a .f2py_f2cmap next to the sources is auto-detected.
+  set(abs_f2cmap)
+  if(F2PY_F2CMAP)
+    if(IS_ABSOLUTE "${F2PY_F2CMAP}")
+      set(abs_f2cmap "${F2PY_F2CMAP}")
+    else()
+      set(abs_f2cmap "${CMAKE_CURRENT_SOURCE_DIR}/${F2PY_F2CMAP}")
+    endif()
+  elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.f2py_f2cmap")
+    set(abs_f2cmap "${CMAKE_CURRENT_SOURCE_DIR}/.f2py_f2cmap")
+  endif()
+
+  set(f2cmap_arg)
+  if(abs_f2cmap)
+    set(f2cmap_arg --f2cmap "${abs_f2cmap}")
+  endif()
+
   # A signature file fully specifies the interface, so f2py reads only it; the
   # sources are compiled and linked separately (via OUTPUT_VARIABLE). Mixing the
   # two on the command line makes f2py reject the bare-subroutine source blocks.
@@ -207,11 +247,11 @@ function(f2py_generate_module NAME)
 
   add_custom_command(
     OUTPUT ${module_output} ${abs_wrapper_files}
-    DEPENDS ${abs_all_files} ${abs_pyf_file}
+    DEPENDS ${abs_all_files} ${abs_pyf_file} ${abs_f2cmap}
     VERBATIM
     COMMAND
       "${${_Python}_EXECUTABLE}" -m numpy.f2py
-      ${f2py_inputs} ${lower} "${F2PY_F2PY_ARGS}"
+      ${f2py_inputs} ${lower} ${f2cmap_arg} "${F2PY_F2PY_ARGS}"
     COMMAND_EXPAND_LISTS
     COMMAND
       "${CMAKE_COMMAND}" -E touch ${abs_wrapper_files}

--- a/tests/packages/f2cmap/.f2py_f2cmap
+++ b/tests/packages/f2cmap/.f2py_f2cmap
@@ -1,0 +1,1 @@
+dict(real=dict(dp='double'))

--- a/tests/packages/f2cmap/CMakeLists.txt
+++ b/tests/packages/f2cmap/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.15...3.29)
+project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
+
+find_package(
+  Python
+  COMPONENTS Interpreter Development.Module NumPy
+  REQUIRED)
+
+include(UseF2Py)
+
+# kinds.f90 uses real(kind=dp); the .f2py_f2cmap next to it (mapping dp ->
+# double) is auto-detected, with no explicit F2CMAP argument.
+f2py_add_module(kinds kinds.f90)
+
+install(TARGETS kinds DESTINATION .)

--- a/tests/packages/f2cmap/kinds.f90
+++ b/tests/packages/f2cmap/kinds.f90
@@ -1,0 +1,10 @@
+module kinds
+  implicit none
+  integer, parameter :: dp = kind(1.0d0)
+contains
+  subroutine scale_dp(x, y)
+    real(kind=dp), intent(in) :: x
+    real(kind=dp), intent(out) :: y
+    y = 2.0_dp * x
+  end subroutine scale_dp
+end module kinds

--- a/tests/packages/f2cmap/pyproject.toml
+++ b/tests/packages/f2cmap/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["scikit-build-core", "numpy", "f2py-cmake"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "example"
+version = "0.0.1"

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -112,6 +112,36 @@ def test_cmix(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(CMAKE is None, reason="CMake not found")
+def test_f2cmap(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # kinds.f90 uses real(kind=dp); without the .f2py_f2cmap mapping dp to
+    # double, f2py can't wrap scale_dp. The file lives next to the sources and
+    # is auto-detected (no explicit F2CMAP arg), so the build and import only
+    # succeed if the source-tree .f2py_f2cmap is found.
+    monkeypatch.chdir(DIR / "packages/f2cmap")
+    build_dir = tmp_path / "build"
+
+    wheel = build_wheel(
+        str(tmp_path), {"build-dir": str(build_dir), "wheel.license-files": []}
+    )
+
+    install_dir = tmp_path / "install"
+    with zipfile.ZipFile(tmp_path / wheel) as f:
+        f.extractall(install_dir)
+
+    monkeypatch.syspath_prepend(str(install_dir))
+    try:
+        # Without the auto-detected .f2py_f2cmap, f2py maps dp to C float and
+        # the dp Fortran argument is fed a single-precision value, losing
+        # precision. A value that only round-trips through double exactly
+        # confirms dp was mapped to double.
+        kinds = importlib.import_module("kinds")
+        x = 0.1
+        assert kinds.kinds.scale_dp(x) == pytest.approx(0.2, abs=1e-15)
+    finally:
+        sys.modules.pop("kinds", None)
+
+
+@pytest.mark.skipif(CMAKE is None, reason="CMake not found")
 def test_f90(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     assert CMAKE is not None
     src_dir = tmp_path / "source"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## The gap

f2py reads custom Fortran kind mappings from a `.f2py_f2cmap` file, and its
`--f2cmap` option **defaults to `.f2py_f2cmap` in the current working
directory**. But both `f2py_generate_signature` and `f2py_generate_module` run
f2py in the **binary dir** (the former uses `CMAKE_CURRENT_BINARY_DIR`, the
latter sets `WORKING_DIRECTORY` to `OUTPUT_DIR`). So a `.f2py_f2cmap` placed
next to the user's sources is never picked up, silently breaking codebases that
use custom kinds such as `real(kind=dp)` (f2py falls back to mapping the kind to
C `float`, producing a precision mismatch against the `real(8)` Fortran).

## What this does

Adds f2cmap support to **both** helpers, with explicit-arg-wins-over-autodetect
behavior:

- **Explicit:** a new single-value `F2CMAP <file>` keyword, resolved to an
  absolute path against `CMAKE_CURRENT_SOURCE_DIR` when relative.
- **Auto-detect:** when `F2CMAP` is not given, a `.f2py_f2cmap` next to the
  sources (`${CMAKE_CURRENT_SOURCE_DIR}/.f2py_f2cmap`) is used if it exists.

The resolved path is passed explicitly as `--f2cmap <abs-path>` (f2py's own cwd
default does not work because the tools run in the build dir) and added to the
`add_custom_command` `DEPENDS` list so editing it retriggers generation. When no
f2cmap is resolved, nothing changes.

```cmake
# Auto-detected from a .f2py_f2cmap next to the sources:
f2py_add_module(kinds kinds.f90)

# Or pointed at explicitly (relative to the source dir):
f2py_generate_module(mymod mymod.f90 F2CMAP maps/types.f2cmap
                     OUTPUT_VARIABLE mymod_files)
```

## Tests

New `tests/packages/f2cmap/` fixture: an F90 module using `real(kind=dp)` with a
`.f2py_f2cmap` (`dict(real=dict(dp='double'))`) alongside the sources, built via
`f2py_add_module` + scikit-build-core. `test_f2cmap` exercises the **auto-detect
path** (no explicit `F2CMAP`), builds a wheel, imports the module, and checks a
double-precision result that only round-trips correctly when `dp` is mapped to
`double`. The whole suite passes locally; lint is clean.

Addresses item #3 of #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)