### PR TITLE
docs: document USE/INCLUDE dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,6 @@ The following are deliberate scope boundaries, not bugs:
   regeneration. Work around this by passing those files explicitly, touching a
   tracked source, or doing a clean rebuild.
 
-- **Pure-C wrapping is out of scope.** These helpers wrap Fortran sources,
-  optionally through a generated or hand-written `.pyf` signature. Wrapping
-  plain C functions via a `.pyf` with `intent(c)` and no Fortran source is not a
-  supported workflow.
-
 ## scikit-build-core
 
 To use this package with scikit-build-core, you need to include it in your build

--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ f2py's own `--f2cmap` default (the cwd) does not work here: these helpers run
 f2py in the build directory, not the source tree, so the file must be located
 explicitly.
 
+## Limitations
+
+The following are deliberate scope boundaries, not bugs:
+
+- **`USE`/`INCLUDE` dependencies are not tracked.** The f2py invocation only
+  depends on the source files you pass to the helper. Files pulled in through
+  Fortran `INCLUDE`, or modules compiled elsewhere and brought in via `USE`, are
+  not listed as dependencies, so editing one of them will not retrigger f2py
+  regeneration. Work around this by passing those files explicitly, touching a
+  tracked source, or doing a clean rebuild.
+
+- **Pure-C wrapping is out of scope.** These helpers wrap Fortran sources,
+  optionally through a generated or hand-written `.pyf` signature. Wrapping
+  plain C functions via a `.pyf` with `intent(c)` and no Fortran source is not a
+  supported workflow.
+
 ## scikit-build-core
 
 To use this package with scikit-build-core, you need to include it in your build


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds a "## Limitations" section to the README documenting two deliberately-scoped limitations:

- **`USE`/`INCLUDE` dependencies are not tracked.** The f2py `add_custom_command` only depends on the source files passed to the helper, so files brought in via Fortran `INCLUDE` or modules imported via `USE` will not retrigger regeneration when edited. Documents the workarounds (pass files explicitly, touch a tracked source, or clean rebuild).
- **Pure-C wrapping is out of scope.** Wrapping plain C functions via a `.pyf` with `intent(c)` and no Fortran source is stated as a scope boundary rather than a bug.

Documents items #4 and #6 of #57.