### PR TITLE
fix: link Python::Module for fortranobject under CMP0201 (CMake 4.2)

### DIFF
--- a/src/f2py_cmake/cmake/UseF2Py.cmake
+++ b/src/f2py_cmake/cmake/UseF2Py.cmake
@@ -42,6 +42,12 @@ target_include_directories(F2Py::Headers INTERFACE "${F2PY_INCLUDE_DIR}")
 function(f2py_object_library NAME TYPE)
   add_library(${NAME} ${TYPE} "${F2PY_INCLUDE_DIR}/fortranobject.c")
   target_link_libraries(${NAME} PUBLIC ${_Python}::NumPy F2Py::Headers)
+  # fortranobject.c includes Python.h, but since CMP0201 (CMake 4.2) the NumPy
+  # target no longer pulls in the Development.Module headers, so link it
+  # explicitly. Guarded so a NumPy-only find_package still falls back gracefully.
+  if(TARGET ${_Python}::Module)
+    target_link_libraries(${NAME} PUBLIC ${_Python}::Module)
+  endif()
   if("${TYPE}" STREQUAL "OBJECT")
     set_property(TARGET ${NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
   endif()

--- a/tests/packages/addmodule/CMakeLists.txt
+++ b/tests/packages/addmodule/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.29)
+cmake_minimum_required(VERSION 3.15...4.2)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
 
 find_package(

--- a/tests/packages/addmodulepyf/CMakeLists.txt
+++ b/tests/packages/addmodulepyf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.29)
+cmake_minimum_required(VERSION 3.15...4.2)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
 
 find_package(

--- a/tests/packages/cmix/CMakeLists.txt
+++ b/tests/packages/cmix/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.29)
+cmake_minimum_required(VERSION 3.15...4.2)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
 
 find_package(

--- a/tests/packages/f2cmap/CMakeLists.txt
+++ b/tests/packages/f2cmap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.29)
+cmake_minimum_required(VERSION 3.15...4.2)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
 
 find_package(

--- a/tests/packages/f77/CMakeLists.txt
+++ b/tests/packages/f77/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.29)
+cmake_minimum_required(VERSION 3.15...4.2)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
 
 find_package(

--- a/tests/packages/f90dual/CMakeLists.txt
+++ b/tests/packages/f90dual/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.24...4.2)
 
 project(test
   LANGUAGES Fortran C

--- a/tests/packages/sig/CMakeLists.txt
+++ b/tests/packages/sig/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.29)
+cmake_minimum_required(VERSION 3.15...4.2)
 project(${SKBUILD_PROJECT_NAME} LANGUAGES C Fortran)
 
 find_package(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

Consumers that raise their CMake policy ceiling to `>=4.2` fail to build with:

```
fortranobject.h:7:10: fatal error: Python.h: No such file or directory
    7 | #include <Python.h>
```

(Originally surfaced as a Fedora example-test failure in scikit-build-core, which uses this same `fortranobject.c` pattern.)

## Root cause

[`CMP0201`](https://cmake.org/cmake/help/latest/policy/CMP0201.html), new in **CMake 4.2**: when the policy is `NEW`, `Python::NumPy` no longer depends on `Python::Development.Module`. `f2py_object_library` compiles numpy's `fortranobject.c` (which `#include <Python.h>`) while linking only `Python::NumPy` + `F2Py::Headers`, so once the policy ceiling reaches 4.2 the Python headers are no longer on the include path.

I bisected the policy ceiling against CMake 4.3.4: builds are fine at `...4.1` and fail at `...4.2`, matching CMP0201 exactly.

## Fix

Link `${_Python}::Module` explicitly in `f2py_object_library`, guarded on the target existing so a NumPy-only `find_package` still degrades gracefully:

```cmake
if(TARGET ${_Python}::Module)
  target_link_libraries(${NAME} PUBLIC ${_Python}::Module)
endif()
```

This is the upgrade path the CMP0201 docs recommend (request/link `Development.Module` explicitly).

## Regression coverage

Bumped the test packages' `cmake_minimum_required` ceiling to `...4.2` so CI exercises CMP0201 `NEW`. Verified locally with CMake 4.3.4 + gfortran:

- With the fix: `9 passed`.
- Fix reverted, ceilings bumped: the 6 f2py-building package tests fail with `Python.h: No such file or directory`; restored: green again.